### PR TITLE
Update RV3129.cpp

### DIFF
--- a/src/RV3129.cpp
+++ b/src/RV3129.cpp
@@ -131,6 +131,8 @@ void RV3129::set24Hour()
 	{		
 		//Not sure what changing the CTRL1 register will do to hour register so let's get a copy
 		uint8_t hour = readRegister(RV3129_HOURS); //Get the current 12 hour formatted time in BCD
+		//Change to 24 hour mode
+		hour &= ~(1<<HOURS_12_24);  //This has to happen before conversion from 1-12 hour range to 0-23 range
 		boolean pm = false;
 		if(hour & (1<<HOURS_AM_PM)) //Is the AM/PM bit set?
 		{
@@ -146,8 +148,6 @@ void RV3129::set24Hour()
 		if(hour == 24) hour = 12; //12PM becomes 24, but should really be 12
 
 		hour = DECtoBCD(hour); //Convert to BCD
-		//Change to 24 hour mode
-		hour &= ~(1<<HOURS_12_24);
 
 		writeRegister(RV3129_HOURS, hour); //Record this to hours register
 	}


### PR DESCRIPTION
I found a bug associated with switching from 12-hour mode to 24-hour mode. Specifically, when converting from 12 hour mode, an hour value of 12 is not detected because the 12-hour select bit (bit 6) is set to 1. As a result the hour is never actually 12, so converting from something like 12:30 am fails, and you get 24:30 in 24-hour mode. The solution is to clear the 12-hour select bit prior to calculating the hour.